### PR TITLE
Updated github stats URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@
 <details>
   <summary>:zap: GitHub Stats</summary>
 
-  <img align="left" alt="codeSTACKr's GitHub Stats" src="https://github-readme-stats.codestackr.vercel.app/api?username=codeSTACKr&show_icons=true&hide_border=true" />
+  <img align="left" alt="codeSTACKr's GitHub Stats" src="https://github-readme-stats.vercel.app/api?username=codeSTACKr&show_icons=true&hide_border=true" />
 
 </details>
 


### PR DESCRIPTION
I have updated your Youtube stats URL, currently it's broken on your profile, however it's resolved in this PR.